### PR TITLE
Adding yarn.lock and vscode settings folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dockerfiles/nginx/conf.d/default.conf
 package-lock.json
 yarn.lock
 .vscode/*
+jsconfig.json


### PR DESCRIPTION
I think we won't need to make more changes to gitignore after this.