### PR TITLE
MigrationByEducation in GeoProfile

### DIFF
--- a/app/pages/GeoProfile/demography/origins/charts/MigrationByEducation.jsx
+++ b/app/pages/GeoProfile/demography/origins/charts/MigrationByEducation.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Section } from "datawheel-canon";
+import { translate } from "react-i18next";
+import { Treemap } from "d3plus-react";
+
+import { simpleGeoChartNeed } from "helpers/MondrianClient";
+import { ordinalColorScale } from "helpers/colors";
+import { numeral } from "helpers/formatters";
+
+import ExportLink from "components/ExportLink";
+
+class MigrationByEducation extends Section {
+  static need = [
+    simpleGeoChartNeed(
+      "path_country_migration_by_education",
+      "immigration",
+      ["Number of visas"],
+      {
+        drillDowns: [["Date", "Year"], ["Education", "Education", "Education"]],
+        options: { parents: true }
+      }
+    )
+  ];
+
+  render() {
+    const { t, className, i18n } = this.props;
+
+    if (!i18n.language) return null;
+    const locale = i18n.language.split("-")[0];
+
+    const path = this.context.data.path_country_migration_by_education;
+
+    return (
+      <div className={className}>
+        <h3 className="chart-title">
+          <span>{t("Migration By Educational Level")}</span>
+          <ExportLink path={path} />
+        </h3>
+        <Treemap
+          config={{
+            height: 500,
+            data: path,
+            groupBy: "ID Education",
+            label: d => d["Education"],
+            sum: d => d["Number of visas"],
+            time: "ID Year",
+            shapeConfig: {
+              fill: d => ordinalColorScale(d["ID Education"])
+            },
+            tooltipConfig: {
+              title: d => d["Education"],
+              body: d =>
+                numeral(d["Number of visas"], locale).format("( 0,0 )") +
+                " " +
+                t("visas")
+            },
+            legendConfig: {
+              label: false,
+              shapeConfig: false
+            }
+          }}
+          dataFormat={data => data.data}
+        />
+      </div>
+    );
+  }
+}
+
+export default translate()(MigrationByEducation);

--- a/app/pages/GeoProfile/index.jsx
+++ b/app/pages/GeoProfile/index.jsx
@@ -110,6 +110,7 @@ import Services from "./environment/amenities/charts/Services";
 /*Demography*/
 import MigrationSlide from "./demography/origins/MigrationSlide";
 import MigrationByOrigin from "./demography/origins/charts/MigrationByOrigin";
+import MigrationByEducation from "./demography/origins/charts/MigrationByEducation";
 
 import MigrationDetailsSlide from "./demography/origins/MigrationDetailsSlide";
 import MigrationBySex from "./demography/origins/charts/MigrationBySex";
@@ -227,6 +228,7 @@ class GeoProfile extends Component {
 
     MigrationSlide,
     MigrationByOrigin,
+    MigrationByEducation,
 
     MigrationDetailsSlide,
     MigrationBySex,
@@ -865,7 +867,8 @@ class GeoProfile extends Component {
               <div>
                 <MigrationSlide>
                   <SectionColumns>
-                    <MigrationByOrigin className="lost-1" />
+                    <MigrationByOrigin className="lost-1-2" />
+                    <MigrationByEducation className="lost-1-2" />
                   </SectionColumns>
                 </MigrationSlide>
               </div>


### PR DESCRIPTION
Adds a treemap of immigrants by educational level alongside immigrants by origin

![image](https://user-images.githubusercontent.com/27584/33337011-68dd8fe4-d450-11e7-9cab-b6e24cec4698.png)
