### PR TITLE
Fix top search transition and body box space wider than screen

### DIFF
--- a/app/components/Nav.css
+++ b/app/components/Nav.css
@@ -40,20 +40,29 @@
     & .r-col {
       lost-column: 1/3;
       & .search-nav-container {
+        position: relative;
         text-align: right;
         display: flex;
         justify-content: flex-end;
         & .search-nav-wrapper {
-          transition: width 0.5s ease;
+          transition: all 0.5s ease;
         }
         & a.search-toggle-nav {
-          padding: 11px 15px;
+          position: absolute;
+          z-index: 40;
+          width: 46px;
+          line-height: 42px;
+          text-align: center;
+          & img {
+            display: inline-block;
+            vertical-align: middle;
+          }
         }
         &.close {
           & a.search-toggle-nav {
           }
           & .search-nav-wrapper {
-            width: 0px;
+            width: 80px;
             opacity: 0;
           }
         }

--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -161,12 +161,12 @@ class Nav extends Component {
                   search_visible ? "open" : "close"
                 }`}
               >
-                <a className="search-toggle-nav" onClick={this.toggleSearch}>
-                  <img src={`/images/icons/${search_icon}.svg`} />
-                </a>
                 <div className={`search-nav-wrapper`}>
                   <Search className="search-nav" />
                 </div>
+                <a className="search-toggle-nav" onClick={this.toggleSearch}>
+                  <img src={`/images/icons/${search_icon}.svg`} />
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
I added a small UX change: now you can close the input without moving the cursor.

Closes #168.