### PR TITLE
adds labels and highlights to Networks

### DIFF
--- a/app/pages/GeoProfile/economy/opportunity/charts/IndustrySpace.jsx
+++ b/app/pages/GeoProfile/economy/opportunity/charts/IndustrySpace.jsx
@@ -43,6 +43,7 @@ class IndustrySpace extends Section {
             links: "/json/isic_4_02_links_d3p2.json",
             nodes: "/json/isic_4_02_nodes_d3p2.json",
             data: path,
+            label: d => d["Level 4"],
             size: "Output RCA",
             // size: "Output",
             sizeMin: 3,
@@ -59,9 +60,6 @@ class IndustrySpace extends Section {
             },
             legend: false,
             tooltipConfig: {
-              title: d => {
-                return d["Level 4"];
-              },
               body: d => numeral(d["Output"], locale).format("(USD 0 a)")
             }
           }}

--- a/app/pages/GeoProfile/economy/opportunity/charts/ProductSpace.jsx
+++ b/app/pages/GeoProfile/economy/opportunity/charts/ProductSpace.jsx
@@ -43,6 +43,7 @@ class ProductSpace extends Section {
             nodes: "/json/hs92_4_nodes_circular_spring_d3p2.json",
             data: path,
             //size: "FOB US",
+            label: d => d.HS2,
             size: "Exports RCA",
             sizeMin: 3,
             sizeMax: 18,
@@ -57,9 +58,6 @@ class ProductSpace extends Section {
                   : ordinalColorScale("hs0" + d["ID HS0"])
             },
             tooltipConfig: {
-              title: d => {
-                return d["HS2"];
-              },
               body: d => {
                 var body = `<table class='tooltip-table'>
                            <tr><td class='title'>${t("Exports USD")}</td></tr>


### PR DESCRIPTION
requires a deep wipe of node_modules to pull in the changes from d3plus-network through canon:

```sh
rm -rf node_modules && rm package-lock.json && npm i
```

I've tested it on this branch, and it looks great! The only thing we should look at is the `sizeMax` variable. I've seen a lot of nodes overlapping (or completely covering) others, and that causes some weird interaction and text labels. By default, the `sizeMax` will be the maximum value allowed, based on the x/y position, without causing an overlap. Maybe just decreasing it a little bit will work.