### PR TITLE
shows a purposefully ugly striped bar when looking at the staging site

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -4,6 +4,7 @@ import Helmet from "react-helmet";
 
 import Footer from "components/Footer";
 import mondrianClient from "helpers/MondrianClient";
+import StagingIndicator from "components/StagingIndicator";
 
 import "./App.css";
 
@@ -35,6 +36,7 @@ class App extends Component {
         <Helmet titleTemplate="%s — DataChile" defaultTitle="DataChile">
           <meta name="description" content={t("home.subtitle")} />
         </Helmet>
+        <StagingIndicator />
         {children}
         <Footer />
       </div>

--- a/app/components/StagingIndicator.css
+++ b/app/components/StagingIndicator.css
@@ -1,0 +1,15 @@
+.staging-indicator {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 10px;
+  font-size: 8px;
+  z-index: 42000;
+  background: repeating-linear-gradient(
+    45deg,
+    yellow,
+    yellow 5px,
+    black 5px,
+    black 10px
+  );
+}

--- a/app/components/StagingIndicator.jsx
+++ b/app/components/StagingIndicator.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+import "./StagingIndicator.css";
+
+export default () =>
+  typeof __STAGING__ !== "undefined" ? (
+    <div className="staging-indicator" />
+  ) : null;


### PR DESCRIPTION
i.e. when `__STAGING__` is defined (usually through the environment var `CANON_CONST_STAGING`.

Like so:

![image](https://user-images.githubusercontent.com/27584/35545360-89f1c672-054d-11e8-998c-c106c205bbad.png)
